### PR TITLE
fix: make candidate form page non-public

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -97,7 +97,6 @@ const routes = [
     path: '/election/:slug/apply',
     name: 'Nomination Form',
     component: () => import('@/pages/election/CandidatureFormPublic.vue'),
-    meta: { isPublicPage: true },
   },
   {
     path: '/election/:slug/c/:id',


### PR DESCRIPTION
fixes #14 

Ideally the candidate form page should be non public.